### PR TITLE
Adds initial eslint-plugin/typescript rules

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,99 @@
+# @sewing-kit/eslint-plugin
+
+ESLint plugin for Shopify
+
+## Installation
+
+You'll first need to install [ESLint](http://eslint.org):
+
+**With Yarn**
+
+```bash
+yarn add --dev eslint
+```
+
+**With npm**
+
+```bash
+$ npm i eslint --save-dev
+```
+
+Next, install `@sewing-kit/eslint-plugin`:
+
+**With Yarn**
+```bash
+yarn add --dev @sewing-kit/eslint-plugin
+```
+
+**With npm**
+```bash
+$ npm install @sewing-kit/eslint-plugin -save-dev
+```
+
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `@sewing-kit/eslint-plugin` globally.
+
+## Usage
+
+Shopify’s ESLint configs come bundled in this package. In order to use them, you simply extend the relevant configuration in your project’s `.eslintrc`. For example, the following will extend the ESNext (ES2015 and later) config:
+
+```json
+{
+  "extends": "plugin:@sewing-kit/esnext"
+}
+```
+
+If you are working on an ES5 project, extend the ES5 version of the configuration:
+
+```json
+{
+  "extends": "plugin:@sewing-kit/es5"
+}
+```
+
+You can also add some "augmenting" configs on top of the "core" config by extending an array of linting configs. For example, the following configuration would provide a base ESNext config that is augmented by a React config:
+
+```json
+{
+  "extends": [
+    "plugin:@sewing-kit/esnext",
+    "plugin:@sewing-kit/react"
+  ]
+}
+```
+
+Likewise, if you are using TypeScript and React, the following configuration extends the TypeScript base config with the React-specific rules provided by the React configuration file. To demonstrate multiple augmentations, we've also added the Prettier config, which disables rules that will conflict in projects using prettier.
+
+```json
+{
+  "extends": [
+    "plugin:@sewing-kit/typescript",
+    "plugin:@sewing-kit/react",
+    "plugin:@sewing-kit/prettier",
+  ]
+}
+```
+
+## Provided configurations
+
+This plugin provides the following core configurations:
+
+- **esnext**: Use this for anything written with ES2015+ features.
+- **typescript**: Use this for Typescript projects. The rules enabled in this confige do not require type-checking to run. To enable all Typescript rules, you must augment this config with the `typescript-type-checking` config mentioned below.
+
+This plugin also provides the following tool-specific configurations, which can be used on top of the core configurations:
+
+- **node**: Use this for Node projects.
+- **react**: Use this for React projects.
+- **graphql**: Use this for projects that use [graphql-config](https://github.com/prisma/graphql-config) for graphql validation.
+- **prettier**: Use [prettier](https://github.com/prettier/prettier) for consistent formatting. Extending this Shopify's prettier config will [override](https://github.com/prettier/eslint-config-prettier/blob/master/index.js) the default Shopify eslint rules in favor of prettier formatting. Prettier must be installed within your project, as eslint-plugin-shopify does not provide the dependency itself.
+
+### Supported Typescript version
+
+The version range of TypeScript currently supported by this plugin is `>=3.2.1 <3.8.0`. This is constrained by the [@typescipt-eslint parser support](https://github.com/typescript-eslint/typescript-eslint#supported-typescript-version).
+
+## Plugin-Provided Rules
+
+This plugin provides the following custom rules, which are included as appropriate in all core linting configs:
+
+- [typescript/prefer-pascal-case-enums](./docs/rules/typescript/prefer-pascal-case-enums.md): Prefer TypeScript enums be defined using Pascal case.
+- [typescript/prefer-singular-enums](./docs/rules/typescript/prefer-singular-enums.md): Prefer TypeScript enums be singular.

--- a/packages/eslint-plugin/docs/rules/typescript/prefer-pascal-case-enums.md
+++ b/packages/eslint-plugin/docs/rules/typescript/prefer-pascal-case-enums.md
@@ -1,0 +1,33 @@
+# Enforce Pascal case when naming enums. (typescript/prefer-pascal-case-enums)
+
+Provides consistency when naming [Enums](https://www.typescriptlang.org/docs/handbook/enums.html) within TypeScript code.
+
+## Rule Details
+
+This rule enforces all TypeScript enums to be in pascal case. An error will occur if another capitalization rule is used (such as snake case or lowercase) when naming TypeScript Enums.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+enum sortorder {
+  most_recent,
+  LEAST_RECENT,
+  newest,
+  OLDEST
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+enum SortOrder {
+  MostRecent,
+  LeastRecent,
+  Newest,
+  Oldest
+}
+```
+
+## When Not To Use It
+
+If you have established coding standards using a different naming convention for TypeScript Enums, you can safely disable this rule.

--- a/packages/eslint-plugin/docs/rules/typescript/prefer-singular-enums.md
+++ b/packages/eslint-plugin/docs/rules/typescript/prefer-singular-enums.md
@@ -1,0 +1,31 @@
+# Prefer singular TypeScript enums. (typescript/prefer-singular-enums)
+
+Provides consistency when naming [enums](https://www.typescriptlang.org/docs/handbook/enums.html) within TypeScript code.
+
+## Rule Details
+
+This rule enforces all TypeScript enums to be singular. An error will occur if the enum is defined with a pluralized name.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+enum Pages {
+  Products,
+  Orders,
+  Discounts,
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+enum Page {
+  Products,
+  Orders,
+  Discounts,
+}
+```
+
+## When Not To Use It
+
+If you have established coding standards using a different naming convention for TypeScript enums, you can safely disable this rule.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -3,9 +3,17 @@
   "license": "MIT",
   "version": "0.0.8",
   "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lemonmade/sewing-kit.git",
+    "directory": "packages/eslint-plugin"
+  },
   "publishConfig": {
     "access": "public",
     "@sewing-kit:registry": "https://registry.npmjs.org"
+  },
+  "devDependencies": {
+    "@types/pluralize": "0.0.29"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^2.10.0",
@@ -24,6 +32,9 @@
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-react-hooks": "^2.3.0",
     "eslint-plugin-sort-class-members": "^1.6.0",
+    "@typescript-eslint/experimental-utils": "2.14.0",
+    "pluralize": "8.0.0",
+    "change-case": "4.1.1",
     "prettier": "^1.19.1"
   },
   "optionalDependencies": {

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -6,7 +6,7 @@ import jest from './config/jest';
 import node from './config/node';
 import prettier from './config/prettier';
 
-export const rules = {};
+export {rules} from './rules';
 
 export const configs = {
   // Core configs - When extending, one of these should go first

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,0 +1,7 @@
+import {preferPascalCaseEnums} from './typescript/prefer-pascal-case-enums';
+import {preferSingularEnums} from './typescript/prefer-singular-enums';
+
+export const rules = {
+  'typescript/prefer-pascal-case-enums': preferPascalCaseEnums,
+  'typescript/prefer-singular-enums': preferSingularEnums,
+};

--- a/packages/eslint-plugin/src/rules/typescript/prefer-pascal-case-enums.ts
+++ b/packages/eslint-plugin/src/rules/typescript/prefer-pascal-case-enums.ts
@@ -1,0 +1,52 @@
+import {pascalCase} from 'change-case';
+import {TSESTree, AST_NODE_TYPES} from '@typescript-eslint/experimental-utils';
+import {createRule} from '../utilities';
+
+export const preferPascalCaseEnums = createRule({
+  name: `typescript/${__filename}`,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Enforce Pascal case when naming enums.',
+      category: 'Stylistic Issues',
+      recommended: false,
+    },
+    messages: {
+      preferPascalCaseEnums: `Enum '{{name}}' should use Pascal case.`,
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create: (context) => {
+    function report(node: TSESTree.Identifier) {
+      const {name} = node;
+
+      context.report({
+        node,
+        messageId: 'preferPascalCaseEnums',
+        data: {name},
+      });
+    }
+
+    return {
+      TSEnumMember({id}) {
+        if (id.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+
+        if (!isPascalCase(id)) {
+          report(id);
+        }
+      },
+      TSEnumDeclaration({id}) {
+        if (!isPascalCase(id)) {
+          report(id);
+        }
+      },
+    };
+  },
+});
+
+function isPascalCase({name}: TSESTree.Identifier) {
+  return name === pascalCase(name);
+}

--- a/packages/eslint-plugin/src/rules/typescript/prefer-singular-enums.ts
+++ b/packages/eslint-plugin/src/rules/typescript/prefer-singular-enums.ts
@@ -1,0 +1,36 @@
+import pluralize from 'pluralize';
+import {createRule} from '../utilities';
+
+export const preferSingularEnums = createRule({
+  name: `typescript/${__filename}`,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Prefer singular TypeScript enums.',
+      category: 'Stylistic Issues',
+      recommended: false,
+    },
+    messages: {
+      preferSingularEnums: `Enum '{{name}}' should be singular.`,
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create: (context) => ({
+    TSEnumDeclaration(node) {
+      const {
+        id: {name},
+      } = node;
+
+      if (pluralize.isSingular(name)) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'preferSingularEnums',
+        data: {name},
+      });
+    },
+  }),
+});

--- a/packages/eslint-plugin/src/rules/typescript/tests/prefer-pascal-case-enums.test.ts
+++ b/packages/eslint-plugin/src/rules/typescript/tests/prefer-pascal-case-enums.test.ts
@@ -1,0 +1,47 @@
+import {TSESLint} from '@typescript-eslint/experimental-utils';
+import {preferPascalCaseEnums} from '../prefer-pascal-case-enums';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+function errorWithName(name: string) {
+  return {
+    data: {name},
+    messageId: 'preferPascalCaseEnums',
+  };
+}
+
+ruleTester.run('prefer-pascal-case-enums', preferPascalCaseEnums, {
+  valid: [
+    {
+      code: `enum SortOrder {MostRecent, LeastRecent, Newest, Oldest}`,
+    },
+  ],
+  invalid: [
+    {
+      code: `enum SORTORDER {MostRecent, LeastRecent, Newest, Oldest}`,
+      errors: [errorWithName('SORTORDER')],
+    },
+    {
+      code: `enum sortorder {MostRecent, LeastRecent, Newest, Oldest}`,
+      errors: [errorWithName('sortorder')],
+    },
+    {
+      code: `enum sort_order {MostRecent, LeastRecent, Newest, Oldest}`,
+      errors: [errorWithName('sort_order')],
+    },
+    {
+      code: `enum sortOrder {MostRecent, LeastRecent, Newest, Oldest}`,
+      errors: [errorWithName('sortOrder')],
+    },
+    {
+      code: `enum sortOrder {mostRecent, LeastRecent, Newest, Oldest}`,
+      errors: [errorWithName('sortOrder'), errorWithName('mostRecent')],
+    },
+    {
+      code: `enum SortOrder {MOSTRECENT, least_recent, Newest, Oldest}`,
+      errors: [errorWithName('MOSTRECENT'), errorWithName('least_recent')],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/typescript/tests/prefer-singular-enums.test.ts
+++ b/packages/eslint-plugin/src/rules/typescript/tests/prefer-singular-enums.test.ts
@@ -1,0 +1,54 @@
+import {TSESLint} from '@typescript-eslint/experimental-utils';
+import {preferSingularEnums} from '../prefer-singular-enums';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+function errorWithName(name: string) {
+  return {
+    data: {name},
+    messageId: 'preferSingularEnums' as 'preferSingularEnums',
+  };
+}
+
+ruleTester.run('prefer-singular-enums', preferSingularEnums, {
+  valid: [
+    {
+      code: `enum SortOrder {MostRecent, LeastRecent, Newest, Oldest}`,
+    },
+    {
+      code: `enum Command {Up, Down}`,
+    },
+    {
+      code: `enum Page {Products, Orders}`,
+    },
+  ],
+  invalid: [
+    {
+      code: `enum SortOrders {MostRecent, LeastRecent, Newest, Oldest}`,
+      errors: [errorWithName('SortOrders')],
+    },
+    {
+      code: `enum Commands {Up, Down}`,
+      errors: [errorWithName('Commands')],
+    },
+    {
+      code: `enum Pages {Products, Orders}`,
+      errors: [errorWithName('Pages')],
+    },
+    {
+      code: `enum Feet {Left, Right}`,
+      errors: [errorWithName('Feet')],
+    },
+
+    {
+      code: `enum People {}`,
+      errors: [errorWithName('People')],
+    },
+    {
+      code: `enum Children {}`,
+      errors: [errorWithName('Children')],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/utilities.ts
+++ b/packages/eslint-plugin/src/rules/utilities.ts
@@ -1,0 +1,18 @@
+import {parse, join} from 'path';
+import {ESLintUtils} from '@typescript-eslint/experimental-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const PACKAGE_JSON = require('../../package.json');
+
+const REPO = getRepoFromPackageJson(PACKAGE_JSON);
+
+export const createRule = ESLintUtils.RuleCreator((name) => {
+  const ruleName = parse(name).name;
+  return `${REPO}/blob/v${PACKAGE_JSON.version}/docs/rules/${ruleName}.md`;
+});
+
+function getRepoFromPackageJson(pkg: any) {
+  const repoPathParts = parse(pkg.repository.url);
+
+  return join(repoPathParts.dir, repoPathParts.name, pkg.repositoroy.directory);
+}


### PR DESCRIPTION
This Pull Request demonstrates adding custom rules to the `eslint-plugin` package. Note these rules are coming from [eslint-plugin-shopify](https://github.com/Shopify/eslint-plugin-shopify), but have been converted to typescript.

I have only pulled in 2 rules as a demonstration. The rules included in this PR are:
- typescript/prefer-pascal-case-enums
- typescript/prefer-singular-enums