### PR TITLE
Prefix root path to build ignore pattern

### DIFF
--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -45,7 +45,7 @@ export async function loadWorkspace(root: string): Promise<LoadedWorkspace> {
 
   const configFiles = glob('**/sewing-kit.config.*', {
     cwd: root as string,
-    ignore: ['**/node_modules/**', '**/build/**'],
+    ignore: ['**/node_modules/**', `${root}/**/build/**`],
     absolute: true,
   });
 


### PR DESCRIPTION
This PR tweaks the globbing used to locate config files for the workspace by specifying that only `build` folders **within** the root should be ignored.

My specific use case is that while trying to run SK-next commands for Quilt in Travis CI, SK-next is unable to detect any configs because the root path is `/home/travis/build/Shopify/quilt`, and so all config files found within the workspace will be excluded by the `**/build/**` rule.