### PR TITLE
Check full plugin name/path

### DIFF
--- a/packages/plugin-javascript/src/tests/utilities.test.ts
+++ b/packages/plugin-javascript/src/tests/utilities.test.ts
@@ -1,0 +1,47 @@
+import {checkForPluginPresetMatch} from '../utilities';
+
+describe('checkForPluginPresetMatch', () => {
+  it('checks to see if an existing plugin matches a list of plugins', () => {
+    const pluginName = 'babble/some-plugin';
+
+    expect(checkForPluginPresetMatch([pluginName], pluginName)).toBe(true);
+  });
+
+  it('does not match a plugin name that is a substring of another plugin name', () => {
+    const pluginName = 'babble/some-plugin';
+    const pluginNameSuffixed = 'babble/some-plugin-other';
+    const pluginNamePrefixed = 'bibblebabble/some-plugin';
+
+    expect(checkForPluginPresetMatch([pluginName], pluginNameSuffixed)).toBe(
+      false,
+    );
+    expect(checkForPluginPresetMatch([pluginNameSuffixed], pluginName)).toBe(
+      false,
+    );
+    expect(checkForPluginPresetMatch([pluginName], pluginNamePrefixed)).toBe(
+      false,
+    );
+    expect(checkForPluginPresetMatch([pluginNamePrefixed], pluginName)).toBe(
+      false,
+    );
+  });
+
+  it('matches a plugin name to a plugin path', () => {
+    const pluginName = 'babble/some-plugin';
+    const pluginPathWithIndex = `/Users/test-user/a/bunch/of/folders/${pluginName}/lib/index.js`;
+    const pluginPathWithoutIndex = `/Users/test-user/a/bunch/of/folders/${pluginName}.js`;
+
+    expect(checkForPluginPresetMatch([pluginPathWithIndex], pluginName)).toBe(
+      true,
+    );
+    expect(checkForPluginPresetMatch([pluginName], pluginPathWithIndex)).toBe(
+      true,
+    );
+    expect(
+      checkForPluginPresetMatch([pluginPathWithoutIndex], pluginName),
+    ).toBe(true);
+    expect(
+      checkForPluginPresetMatch([pluginName], pluginPathWithoutIndex),
+    ).toBe(true);
+  });
+});

--- a/packages/plugin-javascript/src/utilities.ts
+++ b/packages/plugin-javascript/src/utilities.ts
@@ -1,4 +1,4 @@
-import {resolve, relative} from 'path';
+import {resolve, relative, sep} from 'path';
 import {createHash} from 'crypto';
 
 import nodeObjectHash from 'node-object-hash';
@@ -315,7 +315,7 @@ export function updateBabelPlugin<Options extends object = object>(
                 ? plugin
                 : [plugin];
 
-              if (normalizedPlugins.includes(name)) {
+              if (checkForPluginPresetMatch(normalizedPlugins, name)) {
                 hasMatch = true;
 
                 const newOptions = await unwrapPossibleGetter(
@@ -369,7 +369,7 @@ export function updateBabelPreset<Options extends object = object>(
                 ? preset
                 : [preset];
 
-              if (normalizedPresets.includes(name)) {
+              if (checkForPluginPresetMatch(normalizedPresets, name)) {
                 hasMatch = true;
 
                 const newOptions = await unwrapPossibleGetter(
@@ -400,6 +400,31 @@ export function updateBabelPreset<Options extends object = object>(
 
     return newConfig;
   };
+}
+
+export function checkForPluginPresetMatch(
+  searchNames: string[],
+  actualName: string,
+) {
+  return searchNames.some((searchName) => {
+    if (searchName === actualName) return true;
+
+    const delimitedSearchName = delimitName(searchName);
+    const delimitedActualName = delimitName(actualName);
+
+    return (
+      delimitedSearchName.includes(delimitedActualName) ||
+      delimitedActualName.includes(delimitedSearchName)
+    );
+  });
+}
+
+function delimitName(name: string) {
+  let result = name.substr(0, name.lastIndexOf('.')) || name;
+  result = result[0] === sep ? result : sep + result;
+  result = result[result.length - 1] === sep ? result : result + sep;
+
+  return result;
 }
 
 export function updateSewingKitBabelPreset(


### PR DESCRIPTION
This PR slightly modifies the behaviour of two plugin utilities `updateBabelPlugin` and `updateBabelPreset`. It performs a more in-depth check to see whether the list of user-provided plugin/preset names matches the actual plugin/preset name/path.

### Motivating use case

In our project I'm trying to modify some options for two plugins: `@babel/plugin-proposal-decorators` and `@babel/plugin-proposal-class-properties` so we can support legacy decorators.

```
  plugins: [
    [
      '/Users/brianryu/src/github.com/Shopify/quilt/node_modules/@sewing-kit/plugin-javascript/node_modules/@babel/plugin-transform-runtime/lib/index.js',
      {corejs: false, helpers: false, regenerator: true, useESModules: false},
    ],
    [
      '/Users/brianryu/src/github.com/Shopify/quilt/node_modules/@sewing-kit/plugin-typescript/node_modules/@babel/plugin-proposal-decorators/lib/index.js',
      {decoratorsBeforeExport: true},
    ],
    '@babel/plugin-proposal-class-properties',
    '/Users/brianryu/src/github.com/Shopify/quilt/node_modules/@sewing-kit/plugin-typescript/babel-plugin-convert-empty-file-to-esmodule.js',
  ],
```

However in this case I am unable to target `@babel/plugin-proposal-decorators` using either:

- `updateBabelPlugin(require.resolve('@babel/plugin-proposal-decorators'), {legacy: true})`, since because we have this same plugin as another dependency elsewhere in the project, it resolves to a different path than in the config
- `updateBabelPlugin('@babel/plugin-proposal-decorators', {legacy: true})`, since `@babel/plugin-proposal-decorators` is not included in the list of plugin names

Thus it instead adds a duplicate plugin and we get a plugin conflict error during our build.

The goal of this PR is to make it easier to target a specific plugin using just its name, without having to worry about resolved paths.
