### PR TITLE
Set default formatter to esbenp.prettier-vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,7 @@
   "eslint.validate": ["typescript", "typescriptreact", "javascript"],
   "eslint.enable": true,
   "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "cSpell.ignoreWords": [
-    "browserslist"
-  ]
+  "cSpell.ignoreWords": ["browserslist"]
 }


### PR DESCRIPTION
@janiceblundell and I haven't been able to get the prettier's format on save to work in VSCode. After digging into this, I noticed this change fixed the issue. Not sure if this was working, to begin with. I uninstalled `esbenp.prettier-vscode` in favour of `dbaeumer.vscode-eslint` and formatting on save still didn't work. The codebase looks well formatted so perhaps there's a misconfiguration in our editors? 