### PR TITLE
Implement caching for Babel package builds

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -33,14 +33,19 @@ export const build = createCommand(
   {
     '--source-maps': Boolean,
     '--env': String,
+    '--cache': Boolean,
   },
-  async ({'--env': rawEnv, '--source-maps': sourceMaps}, context) => {
+  async (
+    {'--env': rawEnv, '--source-maps': sourceMaps, '--cache': cache = true},
+    context,
+  ) => {
     const env = normalizeEnv(rawEnv);
 
     await runBuild(context, {
       env,
       simulateEnv: env,
       sourceMaps,
+      cache,
     });
   },
 );

--- a/packages/model/src/base/index.ts
+++ b/packages/model/src/base/index.ts
@@ -12,6 +12,8 @@ export interface DependencyOptions {
   prod?: boolean;
 }
 
+export {FileSystem};
+
 export class Base {
   readonly name: string;
   readonly root: string;

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -11,6 +11,7 @@ export {Service} from './service';
 export type {ServiceOptions} from './service';
 export {Workspace} from './workspace';
 export type {WorkspaceOptions} from './workspace';
+export {FileSystem} from './base';
 
 export type Project =
   | import('./package').Package

--- a/packages/plugin-javascript/src/utilities.ts
+++ b/packages/plugin-javascript/src/utilities.ts
@@ -178,16 +178,15 @@ export function createCompileBabelStep({
 
       // Check Babel package build cache
       if (cache) {
-        const cacheValue = generateBabelPackageCacheValue(
-          pkg,
+        const cacheValue = generateBabelPackageCacheValue(pkg, {
           babelConfig,
           outputPath,
-          extension || '.js',
-          exportStyle || ExportStyle.CommonJs,
-          [...babelCacheDependencies],
-          [...babelIgnorePatterns],
-          [...babelExtensions],
-        );
+          extension: extension || '.js',
+          exportStyle: exportStyle || ExportStyle.CommonJs,
+          babelCacheDependencies: [...babelCacheDependencies],
+          babelIgnorePatterns: [...babelIgnorePatterns],
+          babelExtensions: [...babelExtensions],
+        });
         const cachePath = getBabelPackageCachePath(api, pkg.name, configFile);
 
         if (await readBabelPackageCache(cacheValue, cachePath)) {
@@ -282,16 +281,30 @@ function getBabelPackageCachePath(
   );
 }
 
+interface BabelPackageCacheOptions {
+  babelConfig: BabelConfig;
+  outputPath: string;
+  extension: string;
+  exportStyle: ExportStyle;
+  babelCacheDependencies: string[];
+  babelIgnorePatterns: string[];
+  babelExtensions: string[];
+}
+
 function generateBabelPackageCacheValue(
   pkg: Package,
-  babelConfig: BabelConfig,
-  outputPath: string,
-  extension: string,
-  exportStyle: ExportStyle,
-  babelCacheDependencies: string[],
-  babelIgnorePatterns: string[],
-  babelExtensions: string[],
+  options: BabelPackageCacheOptions,
 ) {
+  const {
+    babelConfig,
+    outputPath,
+    extension,
+    exportStyle,
+    babelCacheDependencies,
+    babelIgnorePatterns,
+    babelExtensions,
+  } = options;
+
   const optionsString = [
     outputPath,
     extension,

--- a/packages/plugin-javascript/src/utilities.ts
+++ b/packages/plugin-javascript/src/utilities.ts
@@ -287,7 +287,7 @@ interface BabelPackageCacheOptions {
   babelExtensions: string[];
 }
 
-function generateBabelPackageCacheValue(
+export function generateBabelPackageCacheValue(
   pkg: Package,
   options: BabelPackageCacheOptions,
 ) {
@@ -328,11 +328,18 @@ function createDependencyString(dependencies: string[], project: Project) {
     .join('&');
 }
 
-function getLatestModifiedTime(pkg: Package, babelExtensions: string[]) {
+export function getLatestModifiedTime(pkg: Package, babelExtensions: string[]) {
   const sourceRoot = resolve(pkg.root, 'src');
-  const compiledFiles = glob(
-    `${sourceRoot}/**/*{${babelExtensions.join(',')}}`,
-  );
+  const compiledFiles =
+    babelExtensions.length === 0
+      ? []
+      : glob(
+          `${sourceRoot}/**/*${
+            babelExtensions.length === 1
+              ? babelExtensions[0]
+              : `{${babelExtensions.join(',')}}`
+          }`,
+        );
   return compiledFiles.reduce((latestTime, file) => {
     const {mtimeMs} = stat(file);
 

--- a/packages/plugin-javascript/src/utilities.ts
+++ b/packages/plugin-javascript/src/utilities.ts
@@ -289,9 +289,7 @@ interface BabelPackageCacheOptions {
 
 export function generateBabelPackageCacheValue(
   pkg: Package,
-  options: BabelPackageCacheOptions,
-) {
-  const {
+  {
     babelConfig,
     outputPath,
     extension,
@@ -299,8 +297,8 @@ export function generateBabelPackageCacheValue(
     babelCacheDependencies,
     babelIgnorePatterns,
     babelExtensions,
-  } = options;
-
+  }: BabelPackageCacheOptions,
+) {
   const optionsString = [
     outputPath,
     extension,

--- a/packages/plugin-javascript/src/utilities.ts
+++ b/packages/plugin-javascript/src/utilities.ts
@@ -187,6 +187,9 @@ export function createCompileBabelStep({
         cacheValue = generateBabelPackageCacheValue(
           pkg,
           babelConfig,
+          outputPath,
+          extension || '.js',
+          exportStyle || ExportStyle.CommonJs,
           [...babelCacheDependencies],
           [...babelIgnorePatterns],
           [...babelExtensions],
@@ -289,11 +292,20 @@ function getBabelPackageCachePath(
 function generateBabelPackageCacheValue(
   pkg: Package,
   babelConfig: BabelConfig,
+  outputPath: string,
+  extension: string,
+  exportStyle: ExportStyle,
   babelCacheDependencies: string[],
   babelIgnorePatterns: string[],
   babelExtensions: string[],
 ) {
-  const optionsHash = [...babelIgnorePatterns, ...babelExtensions].join('&');
+  const optionsHash = [
+    outputPath,
+    extension,
+    exportStyle,
+    ...babelIgnorePatterns,
+    ...babelExtensions,
+  ].join('&');
 
   const dependencyString = [...babelCacheDependencies]
     .map(

--- a/packages/plugin-javascript/src/utilities.ts
+++ b/packages/plugin-javascript/src/utilities.ts
@@ -131,8 +131,8 @@ export function createCompileBabelStep({
   configuration,
   configFile,
   outputPath,
-  extension,
-  exportStyle,
+  extension = '.js',
+  exportStyle = ExportStyle.CommonJs,
   cache,
   cacheDependencies: initialCacheDependencies = [],
 }: CompileBabelOptions) {
@@ -181,8 +181,8 @@ export function createCompileBabelStep({
         const cacheValue = generateBabelPackageCacheValue(pkg, {
           babelConfig,
           outputPath,
-          extension: extension || '.js',
-          exportStyle: exportStyle || ExportStyle.CommonJs,
+          extension,
+          exportStyle,
           babelCacheDependencies: [...babelCacheDependencies],
           babelIgnorePatterns: [...babelIgnorePatterns],
           babelExtensions: [...babelExtensions],
@@ -213,10 +213,9 @@ export function createCompileBabelStep({
       );
 
       const sourceRoot = resolve(pkg.root, 'src');
-      const replaceExtension =
-        extension == null || extension.startsWith('.')
-          ? extension
-          : `.${extension}`;
+      const replaceExtension = extension.startsWith('.')
+        ? extension
+        : `.${extension}`;
 
       // TODO: use `cacheDependencies` and cache directories to get good caching going here
       await step.exec('node_modules/.bin/babel', [
@@ -346,9 +345,9 @@ function getLatestModifiedTime(pkg: Package, babelExtensions: string[]) {
 
 async function writeEntries({
   project,
-  extension = '.js',
+  extension,
   outputPath,
-  exportStyle = ExportStyle.CommonJs,
+  exportStyle,
 }: Pick<
   CompileBabelOptions,
   'project' | 'extension' | 'outputPath' | 'exportStyle'

--- a/packages/plugin-javascript/tests/plugin-javascript.test.ts
+++ b/packages/plugin-javascript/tests/plugin-javascript.test.ts
@@ -70,7 +70,6 @@ describe('@sewing-kit/plugin-javascript', () => {
       it('creates a cache', async () => {
         await withWorkspace('simple-package', async (workspace) => {
           await workspace.writeConfig(babelCompilationConfig);
-
           await writeToSrc(workspace, 'index.js');
 
           await workspace.run('build');
@@ -85,20 +84,24 @@ describe('@sewing-kit/plugin-javascript', () => {
 
       it('reads from the cache and skips compilation if hash is same', async () => {
         await withWorkspace('simple-package', async (workspace) => {
-          await workspace.writeConfig(babelCompilationConfig);
+          const builtIndexFilePath = resolve(
+            workspace.root,
+            'build',
+            'esm',
+            'index.mjs',
+          );
 
+          await workspace.writeConfig(babelCompilationConfig);
           await writeToSrc(workspace, 'index.js');
 
           await workspace.run('build');
 
-          const builtOutputModifiedTime = getModifiedTime(
-            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
-          );
+          const builtOutputModifiedTime = getModifiedTime(builtIndexFilePath);
 
           await workspace.run('build');
 
           const updatedBuiltOutputModifiedTime = getModifiedTime(
-            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
+            builtIndexFilePath,
           );
 
           expect(builtOutputModifiedTime).toEqual(
@@ -109,22 +112,26 @@ describe('@sewing-kit/plugin-javascript', () => {
 
       it('invalidates cache if something changes', async () => {
         await withWorkspace('simple-package', async (workspace) => {
-          await workspace.writeConfig(babelCompilationConfig);
+          const builtIndexFilePath = resolve(
+            workspace.root,
+            'build',
+            'esm',
+            'index.mjs',
+          );
 
+          await workspace.writeConfig(babelCompilationConfig);
           await writeToSrc(workspace, 'index.js');
 
           await workspace.run('build');
 
-          const builtOutputModifiedTime = getModifiedTime(
-            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
-          );
+          const builtOutputModifiedTime = getModifiedTime(builtIndexFilePath);
 
           await writeToSrc(workspace, 'index.js');
 
           await workspace.run('build');
 
           const updatedBuiltOutputModifiedTime = getModifiedTime(
-            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
+            builtIndexFilePath,
           );
 
           expect(builtOutputModifiedTime).not.toEqual(

--- a/packages/plugin-javascript/tests/plugin-javascript.test.ts
+++ b/packages/plugin-javascript/tests/plugin-javascript.test.ts
@@ -1,0 +1,86 @@
+import {resolve} from 'path';
+
+import {withWorkspace} from '../../../tests/utilities';
+import {getModifiedTime, writeToSrc} from './utilities';
+
+const babelCompilationConfig = `
+import {createPackage} from '@sewing-kit/config';
+import {javascript} from '@sewing-kit/plugin-javascript';
+import {buildEsModulesOutput} from '@sewing-kit/plugin-package-esmodules';
+
+export default createPackage((pkg) => {
+  pkg.use(javascript(), buildEsModulesOutput());
+});
+`;
+
+describe('@sewing-kit/plugin-javascript', () => {
+  describe('createCompileBabelStep()', () => {
+    describe('caching', () => {
+      it('creates a cache', async () => {
+        await withWorkspace('simple-package', async (workspace) => {
+          await workspace.writeConfig(babelCompilationConfig);
+
+          await writeToSrc(workspace, 'index.js');
+
+          await workspace.run('build');
+
+          expect(
+            await workspace.contains(
+              '.sewing-kit/cache/babel/packages/simple-package/babel-esm-js',
+            ),
+          ).toBe(true);
+        });
+      });
+
+      it('reads from the cache and skips compilation if hash is same', async () => {
+        await withWorkspace('simple-package', async (workspace) => {
+          await workspace.writeConfig(babelCompilationConfig);
+
+          await writeToSrc(workspace, 'index.js');
+
+          await workspace.run('build');
+
+          const builtOutputModifiedTime = getModifiedTime(
+            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
+          );
+
+          await workspace.run('build');
+
+          const updatedBuiltOutputModifiedTime = getModifiedTime(
+            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
+          );
+
+          expect(builtOutputModifiedTime).toEqual(
+            updatedBuiltOutputModifiedTime,
+          );
+        });
+      });
+
+      it('invalidates cache if something changes', async () => {
+        await withWorkspace('simple-package', async (workspace) => {
+          await workspace.writeConfig(babelCompilationConfig);
+
+          await writeToSrc(workspace, 'index.js');
+
+          await workspace.run('build');
+
+          const builtOutputModifiedTime = getModifiedTime(
+            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
+          );
+
+          await writeToSrc(workspace, 'index.js');
+
+          await workspace.run('build');
+
+          const updatedBuiltOutputModifiedTime = getModifiedTime(
+            resolve(workspace.root, 'build', 'esm', 'index.mjs'),
+          );
+
+          expect(builtOutputModifiedTime).not.toEqual(
+            updatedBuiltOutputModifiedTime,
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/plugin-javascript/tests/utilities.test.ts
+++ b/packages/plugin-javascript/tests/utilities.test.ts
@@ -1,21 +1,16 @@
-import {Package} from '@sewing-kit/plugins';
-
 import {withWorkspace} from '../../../tests/utilities';
 import {
   ExportStyle,
   getLatestModifiedTime,
   generateBabelPackageCacheValue,
 } from '../src/utilities';
-import {getModifiedTime, writeToSrc} from './utilities';
+import {getModifiedTime, writeToSrc, createTestPackage} from './utilities';
 
 describe('utilities', () => {
   describe('getLatestModifiedTime()', () => {
     it('gets the latest modified time', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
+        const testPackage = createTestPackage(workspace);
         const fileExtensions = ['.js'];
 
         await writeToSrc(workspace, 'index.js');
@@ -38,10 +33,7 @@ describe('utilities', () => {
 
     it('gets the latest modified time of a group of files', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
+        const testPackage = createTestPackage(workspace);
         const fileExtensions = ['.js', '.ts', '.mjs'];
 
         await writeToSrc(workspace, 'index.js');
@@ -70,12 +62,9 @@ describe('utilities', () => {
       });
     });
 
-    it('excludes files with extensions not included in the provided list', async () => {
+    it('excludes .ts file extensions when it is not included in fileExtensions', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
+        const testPackage = createTestPackage(workspace);
         const fileExtensions = ['.js'];
 
         await writeToSrc(workspace, 'index.js');
@@ -116,35 +105,17 @@ describe('utilities', () => {
 
     it('generates the same hash for unchanged options/dependencies/modified time', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
+        const testPackage = createTestPackage(workspace);
 
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-        const hash2 = generateBabelPackageCacheValue(testPackage, options);
-
-        expect(hash1).toEqual(hash2);
+        expect(generateBabelPackageCacheValue(testPackage, options)).toEqual(
+          generateBabelPackageCacheValue(testPackage, options),
+        );
       });
     });
 
     it('generates a different hash if the Babel config changes', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
-
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-
+        const testPackage = createTestPackage(workspace);
         const newOptions = {
           ...options,
           babelConfig: {
@@ -153,97 +124,57 @@ describe('utilities', () => {
           },
         };
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
-
-        expect(hash1).not.toEqual(hash2);
+        expect(
+          generateBabelPackageCacheValue(testPackage, options),
+        ).not.toEqual(generateBabelPackageCacheValue(testPackage, newOptions));
       });
     });
 
     it('generates a different hash if the output path changes', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
-
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-
+        const testPackage = createTestPackage(workspace);
         const newOptions = {
           ...options,
           outputPath: 'build/meme',
         };
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
-
-        expect(hash1).not.toEqual(hash2);
+        expect(
+          generateBabelPackageCacheValue(testPackage, options),
+        ).not.toEqual(generateBabelPackageCacheValue(testPackage, newOptions));
       });
     });
 
     it('generates a different hash if the extension changes', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
-
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-
+        const testPackage = createTestPackage(workspace);
         const newOptions = {
           ...options,
           extension: '.meme',
         };
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
-
-        expect(hash1).not.toEqual(hash2);
+        expect(
+          generateBabelPackageCacheValue(testPackage, options),
+        ).not.toEqual(generateBabelPackageCacheValue(testPackage, newOptions));
       });
     });
 
     it('generates a different hash if the export style changes', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
-
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-
+        const testPackage = createTestPackage(workspace);
         const newOptions = {
           ...options,
           exportStyle: ExportStyle.CommonJs,
         };
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
-
-        expect(hash1).not.toEqual(hash2);
+        expect(
+          generateBabelPackageCacheValue(testPackage, options),
+        ).not.toEqual(generateBabelPackageCacheValue(testPackage, newOptions));
       });
     });
 
     it('generates a different hash if the cache dependencies change', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
-
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-
+        const testPackage = createTestPackage(workspace);
         const newOptions = {
           ...options,
           babelCacheDependencies: [
@@ -252,99 +183,69 @@ describe('utilities', () => {
           ],
         };
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
-
-        expect(hash1).not.toEqual(hash2);
+        expect(
+          generateBabelPackageCacheValue(testPackage, options),
+        ).not.toEqual(generateBabelPackageCacheValue(testPackage, newOptions));
       });
     });
 
     it('generates a different hash if the ignore patterns change', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
-
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-
+        const testPackage = createTestPackage(workspace);
         const newOptions = {
           ...options,
           babelIgnorePatterns: [...options.babelIgnorePatterns, '.py'],
         };
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
-
-        expect(hash1).not.toEqual(hash2);
+        expect(
+          generateBabelPackageCacheValue(testPackage, options),
+        ).not.toEqual(generateBabelPackageCacheValue(testPackage, newOptions));
       });
     });
 
     it('generates a different hash if the extensions change', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
-
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
-
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
-
+        const testPackage = createTestPackage(workspace);
         const newOptions = {
           ...options,
           babelExtensions: [...options.babelExtensions, '.esnext'],
         };
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
-
-        expect(hash1).not.toEqual(hash2);
+        expect(
+          generateBabelPackageCacheValue(testPackage, options),
+        ).not.toEqual(generateBabelPackageCacheValue(testPackage, newOptions));
       });
     });
 
     it('generates a different hash if the last modified time changes', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
+        const testPackage = createTestPackage(workspace);
 
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
+        await writeToSrc(workspace, 'file.js');
 
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+        const oldHash = generateBabelPackageCacheValue(testPackage, options);
 
-        await writeToSrc(workspace, 'file-b.js');
+        await writeToSrc(workspace, 'file.js');
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, options);
+        const newHash = generateBabelPackageCacheValue(testPackage, options);
 
-        expect(hash1).not.toEqual(hash2);
+        expect(oldHash).not.toEqual(newHash);
       });
     });
 
     it('generates the same hash if only a excluded file changes', async () => {
       await withWorkspace('simple-package', async (workspace) => {
-        const testPackage = new Package({
-          name: 'simple-package',
-          root: workspace.root,
-        });
+        const testPackage = createTestPackage(workspace);
 
-        await writeToSrc(workspace, 'index.js');
-        await writeToSrc(workspace, 'file-a.js');
-        await writeToSrc(workspace, 'file-b.js');
+        await writeToSrc(workspace, 'file.esnext');
 
-        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+        const oldHash = generateBabelPackageCacheValue(testPackage, options);
 
-        await writeToSrc(workspace, 'file-c.esnext');
+        await writeToSrc(workspace, 'file.esnext');
 
-        const hash2 = generateBabelPackageCacheValue(testPackage, options);
+        const newHash = generateBabelPackageCacheValue(testPackage, options);
 
-        expect(hash1).toEqual(hash2);
+        expect(oldHash).toEqual(newHash);
       });
     });
   });

--- a/packages/plugin-javascript/tests/utilities.test.ts
+++ b/packages/plugin-javascript/tests/utilities.test.ts
@@ -1,0 +1,363 @@
+import {statSync as stat} from 'fs';
+
+import {Package} from '@sewing-kit/plugins';
+
+import {withWorkspace, Workspace} from '../../../tests/utilities';
+import {
+  ExportStyle,
+  getLatestModifiedTime,
+  generateBabelPackageCacheValue,
+} from '../src/utilities';
+
+function getModifiedTime(filepath: string) {
+  return stat(filepath).mtimeMs;
+}
+
+async function writeToSrc(workspace: Workspace, filepath: string) {
+  await workspace.writeFile(
+    `src/${filepath}`,
+    `export function pkg(greet) { console.log(\`Hello, \${greet}!\`); }`,
+  );
+}
+
+describe('utilities', () => {
+  describe('getLatestModifiedTime()', () => {
+    it('gets the latest modified time', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+        const fileExtensions = ['.js'];
+
+        await writeToSrc(workspace, 'index.js');
+
+        const latestModifiedTime = getLatestModifiedTime(
+          testPackage,
+          fileExtensions,
+        );
+
+        await writeToSrc(workspace, 'index.js');
+
+        const updatedLatestModifiedTime = getLatestModifiedTime(
+          testPackage,
+          fileExtensions,
+        );
+
+        expect(updatedLatestModifiedTime).toBeGreaterThan(latestModifiedTime);
+      });
+    });
+
+    it('gets the latest modified time of a group of files', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+        const fileExtensions = ['.js', '.ts', '.mjs'];
+
+        await writeToSrc(workspace, 'index.js');
+        const indexModifiedTime = getModifiedTime(
+          testPackage.fs.resolvePath('src', 'index.js'),
+        );
+
+        await writeToSrc(workspace, 'file-a.ts');
+        const fileAModifiedTime = getModifiedTime(
+          testPackage.fs.resolvePath('src', 'file-a.ts'),
+        );
+
+        await writeToSrc(workspace, 'file-b.mjs');
+        const fileBModifiedTime = getModifiedTime(
+          testPackage.fs.resolvePath('src', 'file-b.mjs'),
+        );
+
+        const latestModifiedTime = getLatestModifiedTime(
+          testPackage,
+          fileExtensions,
+        );
+
+        expect(latestModifiedTime).toBeGreaterThan(indexModifiedTime);
+        expect(latestModifiedTime).toBeGreaterThan(fileAModifiedTime);
+        expect(latestModifiedTime).toEqual(fileBModifiedTime);
+      });
+    });
+
+    it('excludes files with extensions not included in the provided list', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+        const fileExtensions = ['.js'];
+
+        await writeToSrc(workspace, 'index.js');
+
+        const latestModifiedTime = getLatestModifiedTime(
+          testPackage,
+          fileExtensions,
+        );
+
+        await writeToSrc(workspace, 'typescript-file.ts');
+
+        const updatedLatestModifiedTime = getLatestModifiedTime(
+          testPackage,
+          fileExtensions,
+        );
+
+        expect(updatedLatestModifiedTime).toEqual(latestModifiedTime);
+      });
+    });
+  });
+
+  describe('generateBabelPackageCacheValue()', () => {
+    const options = {
+      babelConfig: {
+        presets: ['@babel/some-preset', '@babel/some-other-preset'],
+        plugins: ['@babel/some-plugin', '@babel/some-other-plugin'],
+      },
+      outputPath: 'build/esm',
+      extension: '.mjs',
+      exportStyle: ExportStyle.EsModules,
+      babelCacheDependencies: [
+        '@babel/some-plugin',
+        '@babel/some-other-plugin',
+      ],
+      babelIgnorePatterns: ['.json', '.graphql'],
+      babelExtensions: ['.js', '.mjs', '.ts'],
+    };
+
+    it('generates the same hash for unchanged options/dependencies/modified time', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+        const hash2 = generateBabelPackageCacheValue(testPackage, options);
+
+        expect(hash1).toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the Babel config changes', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        const newOptions = {
+          ...options,
+          babelConfig: {
+            ...options.babelConfig,
+            plugins: [...options.babelConfig.plugins, '@babel/some-new-plugin'],
+          },
+        };
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the output path changes', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        const newOptions = {
+          ...options,
+          outputPath: 'build/meme',
+        };
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the extension changes', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        const newOptions = {
+          ...options,
+          extension: '.meme',
+        };
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the export style changes', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        const newOptions = {
+          ...options,
+          exportStyle: ExportStyle.CommonJs,
+        };
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the cache dependencies change', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        const newOptions = {
+          ...options,
+          babelCacheDependencies: [
+            ...options.babelCacheDependencies,
+            '@babel/some-new-cache-dep',
+          ],
+        };
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the ignore patterns change', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        const newOptions = {
+          ...options,
+          babelIgnorePatterns: [...options.babelIgnorePatterns, '.py'],
+        };
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the extensions change', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        const newOptions = {
+          ...options,
+          babelExtensions: [...options.babelExtensions, '.esnext'],
+        };
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, newOptions);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates a different hash if the last modified time changes', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, options);
+
+        expect(hash1).not.toEqual(hash2);
+      });
+    });
+
+    it('generates the same hash if only a excluded file changes', async () => {
+      await withWorkspace('simple-package', async (workspace) => {
+        const testPackage = new Package({
+          name: 'simple-package',
+          root: workspace.root,
+        });
+
+        await writeToSrc(workspace, 'index.js');
+        await writeToSrc(workspace, 'file-a.js');
+        await writeToSrc(workspace, 'file-b.js');
+
+        const hash1 = generateBabelPackageCacheValue(testPackage, options);
+
+        await writeToSrc(workspace, 'file-c.esnext');
+
+        const hash2 = generateBabelPackageCacheValue(testPackage, options);
+
+        expect(hash1).toEqual(hash2);
+      });
+    });
+  });
+});

--- a/packages/plugin-javascript/tests/utilities.test.ts
+++ b/packages/plugin-javascript/tests/utilities.test.ts
@@ -1,24 +1,12 @@
-import {statSync as stat} from 'fs';
-
 import {Package} from '@sewing-kit/plugins';
 
-import {withWorkspace, Workspace} from '../../../tests/utilities';
+import {withWorkspace} from '../../../tests/utilities';
 import {
   ExportStyle,
   getLatestModifiedTime,
   generateBabelPackageCacheValue,
 } from '../src/utilities';
-
-function getModifiedTime(filepath: string) {
-  return stat(filepath).mtimeMs;
-}
-
-async function writeToSrc(workspace: Workspace, filepath: string) {
-  await workspace.writeFile(
-    `src/${filepath}`,
-    `export function pkg(greet) { console.log(\`Hello, \${greet}!\`); }`,
-  );
-}
+import {getModifiedTime, writeToSrc} from './utilities';
 
 describe('utilities', () => {
   describe('getLatestModifiedTime()', () => {

--- a/packages/plugin-javascript/tests/utilities.ts
+++ b/packages/plugin-javascript/tests/utilities.ts
@@ -1,0 +1,14 @@
+import {statSync as stat} from 'fs';
+
+import {Workspace} from '../../../tests/utilities';
+
+export function getModifiedTime(filepath: string) {
+  return stat(filepath).mtimeMs;
+}
+
+export async function writeToSrc(workspace: Workspace, filepath: string) {
+  await workspace.writeFile(
+    `src/${filepath}`,
+    `export function pkg(greet) { console.log(\`Hello, \${greet}!\`); }`,
+  );
+}

--- a/packages/plugin-javascript/tests/utilities.ts
+++ b/packages/plugin-javascript/tests/utilities.ts
@@ -1,6 +1,7 @@
 import {statSync as stat} from 'fs';
 
 import {Workspace} from '../../../tests/utilities';
+import {Package} from '@sewing-kit/plugins';
 
 export function getModifiedTime(filepath: string) {
   return stat(filepath).mtimeMs;
@@ -11,4 +12,8 @@ export async function writeToSrc(workspace: Workspace, filepath: string) {
     `src/${filepath}`,
     `export function pkg(greet) { console.log(\`Hello, \${greet}!\`); }`,
   );
+}
+
+export function createTestPackage(workspace: Workspace) {
+  return new Package({name: 'simple-package', root: workspace.root});
 }

--- a/packages/plugin-package-commonjs/src/plugin-package-commonjs.ts
+++ b/packages/plugin-package-commonjs/src/plugin-package-commonjs.ts
@@ -27,7 +27,12 @@ const setNodeTarget = updateSewingKitBabelPreset({
 
 export function buildCommonJsOutput() {
   return createProjectBuildPlugin<Package>(PLUGIN, (context) => {
-    const {api, hooks, project} = context;
+    const {
+      api,
+      hooks,
+      project,
+      options: {cache},
+    } = context;
 
     hooks.targets.hook((targets) =>
       targets.map((target) =>
@@ -62,6 +67,7 @@ export function buildCommonJsOutput() {
             outputPath,
             configFile: 'babel.cjs.js',
             exportStyle: ExportStyle.CommonJs,
+            cache,
           }),
         ];
       });

--- a/packages/plugin-package-esmodules/src/plugin-package-esmodules.ts
+++ b/packages/plugin-package-esmodules/src/plugin-package-esmodules.ts
@@ -52,7 +52,12 @@ export function esmodulesOutput() {
 
 export function buildEsModulesOutput() {
   return createProjectBuildPlugin<Package>(PLUGIN, (context) => {
-    const {api, hooks, project} = context;
+    const {
+      api,
+      hooks,
+      project,
+      options: {cache},
+    } = context;
 
     hooks.targets.hook((targets) =>
       targets.map((target) =>
@@ -80,6 +85,7 @@ export function buildEsModulesOutput() {
             extension: '.mjs',
             configFile: 'babel.esm.js',
             exportStyle: ExportStyle.EsModules,
+            cache,
           }),
         ];
       });

--- a/packages/plugin-package-esmodules/tests/plugin-package-esmodules.test.ts
+++ b/packages/plugin-package-esmodules/tests/plugin-package-esmodules.test.ts
@@ -2,7 +2,7 @@ import {join} from 'path';
 import {withWorkspace} from '../../../tests/utilities';
 
 describe('@sewing-kit/plugin-package-esmodules', () => {
-  it('builds a package at root while preserving ES import/ exports', async () => {
+  it('builds a package at root while preserving ES import/exports', async () => {
     await withWorkspace('simple-package', async (workspace) => {
       await workspace.writeConfig(`
         import {createPackage} from '@sewing-kit/config';

--- a/packages/plugin-package-esnext/src/plugin-package-esnext.ts
+++ b/packages/plugin-package-esnext/src/plugin-package-esnext.ts
@@ -105,7 +105,12 @@ export function esnextOutput() {
 
 export function buildEsNextOutput() {
   return createProjectBuildPlugin<Package>(PLUGIN, (context) => {
-    const {api, hooks, project} = context;
+    const {
+      api,
+      hooks,
+      project,
+      options: {cache},
+    } = context;
 
     hooks.targets.hook((targets) =>
       targets.map((target) =>
@@ -139,6 +144,7 @@ export function buildEsNextOutput() {
             extension: EXTENSION,
             configFile: 'babel.esnext.js',
             exportStyle: ExportStyle.EsModules,
+            cache,
           }),
         ];
       });

--- a/packages/plugin-package-node/src/plugin-package-node.ts
+++ b/packages/plugin-package-node/src/plugin-package-node.ts
@@ -32,7 +32,12 @@ export function nodeOutput() {
 
 export function buildNodeOutput() {
   return createProjectBuildPlugin<Package>(PLUGIN, (context) => {
-    const {api, hooks, project} = context;
+    const {
+      api,
+      hooks,
+      project,
+      options: {cache},
+    } = context;
 
     hooks.targets.hook((targets) =>
       targets.map((target) => {
@@ -76,6 +81,7 @@ export function buildNodeOutput() {
             configuration,
             configFile: 'babel.node.js',
             exportStyle: ExportStyle.CommonJs,
+            cache,
           }),
         ];
       });


### PR DESCRIPTION
This PR adds caching to `createCompileBabelStep` in `plugin-javascript` (used for transpiling packages). Currently TS builds are cached, however when building JS using the Babel CLI we rebuild each package from scratch (Babel CLI doesn't seem to support caching OOTB).

How the cache works is that it generates a hash based on several compilation-relevant factors (including Babel configs, deps, etc.) in addition to the latest modified time (`mtimeMs`) of the files in the package's `src` folder. If it doesn't match the hash stored in `.sewing-kit/cache/babel` (i.e. the config/deps have changed, or the files have been modified since the last build), then it rebuilds. Otherwise it skips. This helps reduce warm build times in workspaces with many packages but with usually only a few being worked on at any given time.

### To do
- [x] Add tests

### Benchmarking

_Note: Quilt build times vary somewhat, particularly for cold builds. The "Before" ones listed below are on the fast end, wasn't able to get a good "average" time 😕_

#### In Sewing Kit (self-build)

| | Before | After |
| --- | --- | --- |
| **Cold** | <img width="316" alt="Screen Shot 2020-08-17 at 11 19 48 AM" src="https://user-images.githubusercontent.com/46533681/90412852-a27e3200-e07b-11ea-9e48-ca2af9f2da0d.png"> | <img width="226" alt="Screen Shot 2020-08-17 at 11 15 52 AM" src="https://user-images.githubusercontent.com/46533681/90412456-208e0900-e07b-11ea-8fa1-c1c7aa659eaf.png"> |
| **Warm** | <img width="350" alt="Screen Shot 2020-08-17 at 11 20 08 AM" src="https://user-images.githubusercontent.com/46533681/90412875-aad66d00-e07b-11ea-971f-3dfb52296a76.png"> | <img width="278" alt="Screen Shot 2020-08-17 at 11 16 24 AM" src="https://user-images.githubusercontent.com/46533681/90412482-27b51700-e07b-11ea-8e1d-e6141857a0fa.png"> | 

#### In [Quilt](https://github.com/Shopify/quilt/tree/1522-sk-next)

| | Before | After |
| --- | --- | --- |
| **Cold** | <img width="253" alt="Screen Shot 2020-08-17 at 12 07 23 PM" src="https://user-images.githubusercontent.com/46533681/90423219-1293b480-e08a-11ea-8f97-5cf5b5a53927.png"> | <img width="252" alt="Screen Shot 2020-08-17 at 1 14 24 PM" src="https://user-images.githubusercontent.com/46533681/90424146-a2862e00-e08b-11ea-8ec4-a1b67320a474.png"> |
| **Warm** | <img width="249" alt="Screen Shot 2020-08-17 at 12 10 58 PM" src="https://user-images.githubusercontent.com/46533681/90423238-19222c00-e08a-11ea-8385-fa4584052016.png"> | <img width="243" alt="Screen Shot 2020-08-17 at 1 15 16 PM" src="https://user-images.githubusercontent.com/46533681/90424197-b598fe00-e08b-11ea-86b9-9fab107f3f9f.png"> |