### PR TITLE
Jest config improvements

### DIFF
--- a/packages/plugin-jest/src/plugin-jest.ts
+++ b/packages/plugin-jest/src/plugin-jest.ts
@@ -353,7 +353,7 @@ function packageEntryMatcherMap({runtimeName, entries, fs}: Package) {
 
   for (const {name, root} of entries) {
     map[
-      name ? join(runtimeName, `${name}$`) : `${runtimeName}$`
+      name ? `^${join(runtimeName, name)}$` : `^${runtimeName}$`
     ] = fs.resolvePath(root);
   }
 

--- a/packages/plugin-jest/tests/plugin-jest.test.ts
+++ b/packages/plugin-jest/tests/plugin-jest.test.ts
@@ -1,0 +1,24 @@
+import {liftRepeatedValueInJSONString} from '../src/plugin-jest';
+
+describe('@sewing-kit/plugin-jest', () => {
+  describe('liftRepeatedValueInJSONString()', () => {
+    it('replaces all instances of a repeated value with a const', () => {
+      const repeatedValue = {key: 'value'};
+      const obj = {
+        key1: repeatedValue,
+        key2: repeatedValue,
+        key3: repeatedValue,
+      };
+
+      const oldJSONString = JSON.stringify(obj);
+      const newJSONString = liftRepeatedValueInJSONString(JSON.stringify(obj), {
+        repeatedValue: JSON.stringify(repeatedValue),
+      });
+
+      expect(newJSONString).not.toEqual(oldJSONString);
+      expect(newJSONString).toEqual(
+        `const repeatedValue = {"key":"value"};{"key1":repeatedValue,"key2":repeatedValue,"key3":repeatedValue}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Resolves #56 

This PR does two things:
- Tweaks the [module mapper regex](https://github.com/lemonmade/sewing-kit/issues/56) so that it unambiguously resolves to a single module
- Add a utility to help shrink down the root Jest config written by `plugin-jest` (doesn't have an issue, more details below)

**`liftRepeatedValueInJSONString()`**

The Jest plugin provided by `@sewing-kit/plugin-jest` writes a JS Jest config to `.sewing-kit/config/jest/root.config.js`, with each individual project in the workspace getting its own config nested in the larger config object. Each project config gets its own `moduleNameMapper` key, which is set to a default module mapper value generated by the plugin. If the consumer doesn't do anything to modify the mapper by way of hooks, then each project config gets its own identical module mapper object, which can be relatively large on its own. For large monorepo workspaces like Quilt, this means that the `root.config.js` blows up to a very large size that makes it difficult for VS Code to parse and thus difficult for devs to go in and debug.

This util extracts repeated values to consts and places them at the top of the stringified config, cutting down on the repetition and making the config much smaller.

_Note: I initially tried lifting the mapper to the outer config object, but the project configs don't seem to extend the outer one_ 🤷 

**Before**
```js
module.exports = {
  packages: {
    somePackageName: {
      moduleNameMapper: {
        key1: "value",
        key2: "value",
        key3: "value",
        key4: "value",
        key5: "value"
      }
    },
    someOtherPackageName: {
      moduleNameMapper: {
        key1: "value",
        key2: "value",
        key3: "value",
        key4: "value",
        key5: "value"
      }
    }
  }
}
```

**After**
```js
const value = {
  key1: "value",
  key2: "value",
  key3: "value",
  key4: "value",
  key5: "value"
};
module.exports = {
  packages: {
    somePackageName: {
      moduleNameMapper: value
    },
    someOtherPackageName: {
      moduleNameMapper: value
    },
  }
}
```