### PR TITLE
Minimal module mapping

### DIFF
--- a/packages/plugin-jest/package.json
+++ b/packages/plugin-jest/package.json
@@ -12,6 +12,7 @@
     "@sewing-kit/plugins": "^0.1.4",
     "@types/jest": "^25.2.2",
     "babel-jest": "^26.0.0",
+    "dependency-graph": "^0.9.0",
     "jest": "^26.0.0",
     "jest-watch-typeahead": "^0.6.0"
   },

--- a/packages/plugin-jest/src/plugin-jest.ts
+++ b/packages/plugin-jest/src/plugin-jest.ts
@@ -353,7 +353,7 @@ export function jest() {
 }
 
 // Creates a dependency graph of internal packages
-function internalPackageDependencyGraph(
+export function internalPackageDependencyGraph(
   packages: Package[],
   packageMap: Record<string, any>,
 ): DepGraph<string> {
@@ -374,7 +374,7 @@ function internalPackageDependencyGraph(
 }
 
 // Creates a map of internal packages to their entry module mapping
-function internalPackageEntryMapDict(
+export function internalPackageEntryMapDict(
   packages: Package[],
 ): Record<string, Record<string, string>> {
   return packages.reduce(
@@ -390,17 +390,21 @@ function packageEntryMatcherMap({runtimeName, entries, fs}: Package) {
   const map: Record<string, string> = Object.create(null);
 
   for (const {name, root} of entries) {
-    map[`^${name ? join(runtimeName, name) : runtimeName}$`] = fs.resolvePath(
-      root,
-    );
+    map[
+      moduleMapKey(name ? join(runtimeName, name) : runtimeName)
+    ] = fs.resolvePath(root);
   }
 
   return map;
 }
 
+export function moduleMapKey(packageName: string) {
+  return `^${packageName}$`;
+}
+
 // Creates a minimal module mapping for the project's Jest config
 // Jest requires that every dependency down the tree be mapped, not just its immediate deps
-function minimalModuleMap(
+export function minimalModuleMap(
   project: Project,
   packageEntryMapDict: Record<string, Record<string, string>>,
   packageDependencyGraph: DepGraph<string>,

--- a/packages/plugin-jest/src/plugin-jest.ts
+++ b/packages/plugin-jest/src/plugin-jest.ts
@@ -364,7 +364,7 @@ function internalPackageDependencyGraph(
   });
   packages.forEach((pkg) => {
     pkg.dependencies({all: true}).forEach((dep) => {
-      if (packageMap[dep] !== undefined) {
+      if (isInternalPackage(dep, packageMap)) {
         depGraph.addDependency(pkg.runtimeName, dep);
       }
     });
@@ -408,7 +408,7 @@ function minimalModuleMap(
   const projectDeps = project.dependencies({all: true});
 
   return projectDeps.reduce((map, dep) => {
-    if (packageEntryMapDict[dep] !== undefined) {
+    if (isInternalPackage(dep, packageEntryMapDict)) {
       const depDeps = packageDependencyGraph.dependenciesOf(dep);
 
       return depDeps.reduce(
@@ -424,4 +424,11 @@ function minimalModuleMap(
       return map;
     }
   }, {});
+}
+
+function isInternalPackage(
+  dependencyName: string,
+  packageMap: Record<string, any>,
+) {
+  return packageMap[dependencyName] !== undefined;
 }

--- a/packages/plugin-jest/tests/plugin-jest.test.ts
+++ b/packages/plugin-jest/tests/plugin-jest.test.ts
@@ -1,0 +1,1 @@
+describe('@sewing-kit/plugin-jest', () => {});

--- a/packages/plugin-jest/tests/plugin-jest.test.ts
+++ b/packages/plugin-jest/tests/plugin-jest.test.ts
@@ -1,1 +1,104 @@
-describe('@sewing-kit/plugin-jest', () => {});
+import {Package} from '@sewing-kit/plugins';
+import {PackageEntryOptions} from '@sewing-kit/model';
+
+import {
+  internalPackageEntryMapDict,
+  internalPackageDependencyGraph,
+  minimalModuleMap,
+  moduleMapKey,
+} from '../src/plugin-jest';
+
+describe('@sewing-kit/plugin-jest', () => {
+  describe('Module map', () => {
+    describe('internalPackageEntryMapDict()', () => {
+      it('creates a map of internal packages to their resolved entries', () => {
+        const pkgs = createMockPackageList([
+          {
+            name: 'pkg-a',
+            deps: [],
+            entries: [{root: './entry-a', name: 'entry-a'}],
+          },
+        ]);
+
+        const pkgMap = internalPackageEntryMapDict(pkgs);
+
+        expect(pkgMap).toHaveProperty('pkg-a');
+        expect(pkgMap['pkg-a']).toHaveProperty(moduleMapKey('pkg-a'));
+        expect(pkgMap['pkg-a']).toHaveProperty(moduleMapKey('pkg-a/entry-a'));
+      });
+    });
+
+    describe('minimalModuleMap()', () => {
+      it('produces a minimal map of internal module dependencies', () => {
+        const pkg = createMockPackage({
+          name: 'pkg-a',
+          deps: ['pkg-b', 'ext-pkg'],
+        });
+        const pkgs = [
+          pkg,
+          ...createMockPackageList([
+            {name: 'pkg-b', deps: ['pkg-a']},
+            {name: 'pkg-c', deps: ['pkg-b']},
+            {name: 'pkg-d', deps: ['pkg-a', 'pkg-b']},
+          ]),
+        ];
+
+        const pkgMap = internalPackageEntryMapDict(pkgs);
+        const depGraph = internalPackageDependencyGraph(pkgs, pkgMap);
+        const minMap = minimalModuleMap(pkg, pkgMap, depGraph);
+
+        expect(minMap).toHaveProperty(moduleMapKey('pkg-b'));
+        expect(minMap).toHaveProperty(moduleMapKey('pkg-a'));
+        expect(minMap).not.toHaveProperty(moduleMapKey('pkg-c'));
+        expect(minMap).not.toHaveProperty(moduleMapKey('pkg-d'));
+        expect(minMap).not.toHaveProperty(moduleMapKey('ext-pkg'));
+      });
+    });
+
+    describe('moduleMapKey()', () => {
+      it('matches the exact module name', () => {
+        const moduleKey = moduleMapKey('pkg-a');
+        const keyRegex = new RegExp(moduleKey);
+
+        expect(keyRegex.test('pkg-a')).toBe(true);
+      });
+
+      it(`doesn't match other module names`, () => {
+        const moduleKey = moduleMapKey('pkg-a');
+        const keyRegex = new RegExp(moduleKey);
+
+        expect(keyRegex.test('pkg-a-suffix')).toBe(false);
+        expect(keyRegex.test('prefix-pkg-a')).toBe(false);
+      });
+    });
+  });
+});
+
+interface MockPackageOptions {
+  name: string;
+  deps: string[];
+  entries?: PackageEntryOptions[];
+}
+
+function createMockPackage({
+  name,
+  deps,
+  entries = [],
+}: MockPackageOptions): Package {
+  const pkg = new Package({
+    name,
+    root: `package/${name}`,
+    entries: [{root: 'index'}, ...entries],
+  });
+
+  Object.defineProperty(pkg, 'runtimeName', {
+    get: jest.fn(() => name),
+  });
+  jest.spyOn(pkg, 'dependencies').mockImplementation(() => deps);
+
+  return pkg;
+}
+
+function createMockPackageList(packages: MockPackageOptions[]) {
+  return packages.map(createMockPackage);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,18 +2537,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
+"@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
-
-"@types/vfile-message@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-1.0.1.tgz#e1e9895cc6b36c462d4244e64e6d0b6eaf65355a"
-  integrity sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==
-  dependencies:
-    "@types/node" "*"
-    "@types/unist" "*"
 
 "@types/webpack-dev-middleware@*":
   version "2.0.3"
@@ -4805,6 +4797,11 @@ depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+dependency-graph@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.9.0.tgz#11aed7e203bc8b00f48356d92db27b265c445318"
+  integrity sha512-9YLIBURXj4DJMFALxXw9K3Y3rwb5Fk0X5/8ipCzaN84+gKxoHK43tVKRNakCQbiEx07E8Uwhuq21BpUagFhZ8w==
 
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
Split off from #57 
There's some merge conflicts with #58, so I'll have to resolve those depending on if/when either of these get merged in but I thought I'd throw up a PR anyway for review purposes

**To do**
- [x] Need to add tests

**Issue (copied from old PR)** 

> The Jest plugin provided by @sewing-kit/plugin-jest writes a JS Jest config to `.sewing-kit/config/jest/root.config.js`, with each individual project in the workspace getting its own config nested in the larger config object. Each project config gets its own `moduleNameMapper` key, which is set to a default module mapper value generated by the plugin. If the consumer doesn't do anything to modify the mapper by way of hooks, then each project config gets its own identical module mapper object, which can be relatively large on its own. For large monorepo workspaces like Quilt, this means that the `root.config.js` blows up to a very large size that makes it difficult for VS Code to parse and thus difficult for devs to go in and debug.

Instead of messing around with stringified JS we instead put together a minimal module mapping required for each project to run its tests.

Jest requires that all modules down the dependency tree of a project be mapped, so it's not enough to simply read off `package.json`. For that we pull in a new dependency [`dependency-graph`](https://www.npmjs.com/package/dependency-graph) to build a dependency graph for us (npm stats look pretty legit, dunno if there's a more common/popular solution).